### PR TITLE
Give more time for stale issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,9 +1,9 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 60
+daysUntilStale: 90
 # Number of days of inactivity before a stale Issue or Pull Request is closed
-daysUntilClose: 7
+daysUntilClose: 30
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
   - pinned


### PR DESCRIPTION
I've found stale to be a little too aggressive for the level of activity on Probot right now. This backs the prompt down from 60 to 90 days, and gives 30 days before closing.